### PR TITLE
🎨 Palette: Improve header and footer accessibility in README

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-11 - [Improved Alt Text for Profile Headers and Footers]
+**Learning:** Generic alt text like "header" or "footer" for generated images (e.g. via capsule-render) does not provide adequate context for screen readers. Header images often contain meaningful text or information about the person, while footer images are often purely decorative.
+**Action:** Replace generic alt text on meaningful header images with the actual content/context of the image (e.g., "Name - Titles"). Use empty alt text (`![]`) for purely decorative images like a standard footer graphic so screen readers can safely skip over them.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![header](https://capsule-render.vercel.app/api?type=waving&height=200&color=0:7c3aed,50:1a1a2e,100:22c55e&text=Noah%20Weidig&fontSize=60&fontColor=ffffff&fontAlign=50&fontAlignY=45&desc=GIS%20Analyst%20%C2%B7%20Data%20Scientist%20%C2%B7%20Remote%20Sensing&descColor=d0d0ff&descSize=16&descAlign=50&descAlignY=65)
+![Noah Weidig - GIS Analyst, Data Scientist, Remote Sensing](https://capsule-render.vercel.app/api?type=waving&height=200&color=0:7c3aed,50:1a1a2e,100:22c55e&text=Noah%20Weidig&fontSize=60&fontColor=ffffff&fontAlign=50&fontAlignY=45&desc=GIS%20Analyst%20%C2%B7%20Data%20Scientist%20%C2%B7%20Remote%20Sensing&descColor=d0d0ff&descSize=16&descAlign=50&descAlignY=65)
 
 </div>
 
@@ -115,6 +115,6 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-![footer](https://capsule-render.vercel.app/api?type=waving&height=80&color=0:22c55e,50:1a1a2e,100:7c3aed&section=footer&reversal=true)
+![](https://capsule-render.vercel.app/api?type=waving&height=80&color=0:22c55e,50:1a1a2e,100:7c3aed&section=footer&reversal=true)
 
 </div>


### PR DESCRIPTION
**🎨 Palette: Improve header and footer accessibility in README**

💡 **What:** 
- Updated the main header image's alt text from `![header]` to include the text it displays: `![Noah Weidig - GIS Analyst, Data Scientist, Remote Sensing]`.
- Updated the decorative footer image from `![footer]` to empty alt text `![]`.
- Added a new learning journal entry to `.Jules/palette.md`.

🎯 **Why:** 
Generic alt text like "header" or "footer" provides no context for visually impaired users relying on screen readers. Adding the exact text from the header ensures all users get the same information, while using empty alt text on the purely decorative footer allows screen readers to correctly skip it without reading unhelpful information.

♿ **Accessibility:** 
- Improved image semantics and context for screen readers parsing markdown.
- Appropriate handling of purely decorative images.

---
*PR created automatically by Jules for task [17985487765602375694](https://jules.google.com/task/17985487765602375694) started by @noahweidig*