### PR TITLE
🎨 Palette: Improve dynamic image screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-11 - Dynamic Image Accessibility in Profile Readmes
+**Learning:** Automatically generated header and footer images (e.g. via capsule-render APIs) often contain readable text that screen readers completely miss if given generic alt text like "header". Meanwhile, footer images are often purely visual decoration. This creates an inconsistent screen reader experience.
+**Action:** When working with dynamic README images, always transcribe the generated text content into the `alt` attribute for headers, and use an empty `alt` attribute (`![]()`) for purely decorative images to reduce noise.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![header](https://capsule-render.vercel.app/api?type=waving&height=200&color=0:7c3aed,50:1a1a2e,100:22c55e&text=Noah%20Weidig&fontSize=60&fontColor=ffffff&fontAlign=50&fontAlignY=45&desc=GIS%20Analyst%20%C2%B7%20Data%20Scientist%20%C2%B7%20Remote%20Sensing&descColor=d0d0ff&descSize=16&descAlign=50&descAlignY=65)
+![Noah Weidig - GIS Analyst, Data Scientist, Remote Sensing](https://capsule-render.vercel.app/api?type=waving&height=200&color=0:7c3aed,50:1a1a2e,100:22c55e&text=Noah%20Weidig&fontSize=60&fontColor=ffffff&fontAlign=50&fontAlignY=45&desc=GIS%20Analyst%20%C2%B7%20Data%20Scientist%20%C2%B7%20Remote%20Sensing&descColor=d0d0ff&descSize=16&descAlign=50&descAlignY=65)
 
 </div>
 
@@ -115,6 +115,6 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-![footer](https://capsule-render.vercel.app/api?type=waving&height=80&color=0:22c55e,50:1a1a2e,100:7c3aed&section=footer&reversal=true)
+![](https://capsule-render.vercel.app/api?type=waving&height=80&color=0:22c55e,50:1a1a2e,100:7c3aed&section=footer&reversal=true)
 
 </div>


### PR DESCRIPTION
💡 **What:** Transcribed the actual text rendered in the header capsule image into its `alt` attribute and removed the generic "footer" alt text from the purely decorative footer wave image.

🎯 **Why:** The automatically generated header image contains the user's name and title, but screen readers were just reading "header". The footer is purely decorative, but screen readers were reading "footer", adding noise.

📸 **Before/After:** Not a visual change, but a significant accessibility improvement for screen readers.

♿ **Accessibility:** Screen reader users will now hear "Noah Weidig - GIS Analyst, Data Scientist, Remote Sensing" instead of "header", and will correctly skip the decorative footer wave.

*Added learning to `.Jules/palette.md`.*

---
*PR created automatically by Jules for task [13573365648292691181](https://jules.google.com/task/13573365648292691181) started by @noahweidig*