### PR TITLE
🎨 Palette: Fix accessibility for profile badges and decorative footer image

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-11 - [Improved Alt Text for Profile Headers and Footers]
 **Learning:** Generic alt text like "header" or "footer" for generated images (e.g. via capsule-render) does not provide adequate context for screen readers. Header images often contain meaningful text or information about the person, while footer images are often purely decorative.
 **Action:** Replace generic alt text on meaningful header images with the actual content/context of the image (e.g., "Name - Titles"). Use empty alt text (`![]`) for purely decorative images like a standard footer graphic so screen readers can safely skip over them.
+## 2026-03-11 - [Accessible Alt Text for Two-Sided Badges]
+**Learning:** Screen readers announce the `alt` text of images. For two-sided status badges (like shields.io) often used for links, generic `alt` text like `![Email]` causes screen readers to miss the right side of the badge (e.g., the actual email address or username).
+**Action:** Always write alt text for two-sided badges that describes the full visual text or intent, e.g., `![Email: noah@noahweidig.com]` or `![LinkedIn Connect]` instead of just the label.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ If Earth has a pattern, I want to find it.</em></p>
 
 <br/>
 
-[![Email](https://img.shields.io/badge/Email-noah%40noahweidig.com-7c3aed?style=flat-square&logo=minutemailer&logoColor=white&labelColor=1a1a2e)](mailto:noah@noahweidig.com)&nbsp;
-[![Website](https://img.shields.io/badge/Website-noahweidig.com-6d28d9?style=flat-square&logo=safari&logoColor=white&labelColor=1a1a2e)](https://noahweidig.com)&nbsp;
-[![Substack](https://img.shields.io/badge/Substack-Newsletter-4f46e5?style=flat-square&logo=substack&logoColor=white&labelColor=1a1a2e)](https://noahweidig.substack.com/)&nbsp;
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-2563eb?style=flat-square&logo=linkedin&logoColor=white&labelColor=1a1a2e)](https://www.linkedin.com/in/noahweidig/)&nbsp;
-[![ORCID](https://img.shields.io/badge/ORCID-Profile-06b6d4?style=flat-square&logo=orcid&logoColor=white&labelColor=1a1a2e)](https://orcid.org/0000-0003-1205-3209)&nbsp;
-[![Scholar](https://img.shields.io/badge/Google-Scholar-0ea5e9?style=flat-square&logo=googlescholar&logoColor=white&labelColor=1a1a2e)](https://scholar.google.com/citations?user=Ml95eTwAAAAJ&hl=en)
+[![Email: noah@noahweidig.com](https://img.shields.io/badge/Email-noah%40noahweidig.com-7c3aed?style=flat-square&logo=minutemailer&logoColor=white&labelColor=1a1a2e)](mailto:noah@noahweidig.com)&nbsp;
+[![Website: noahweidig.com](https://img.shields.io/badge/Website-noahweidig.com-6d28d9?style=flat-square&logo=safari&logoColor=white&labelColor=1a1a2e)](https://noahweidig.com)&nbsp;
+[![Substack Newsletter](https://img.shields.io/badge/Substack-Newsletter-4f46e5?style=flat-square&logo=substack&logoColor=white&labelColor=1a1a2e)](https://noahweidig.substack.com/)&nbsp;
+[![LinkedIn Connect](https://img.shields.io/badge/LinkedIn-Connect-2563eb?style=flat-square&logo=linkedin&logoColor=white&labelColor=1a1a2e)](https://www.linkedin.com/in/noahweidig/)&nbsp;
+[![ORCID Profile](https://img.shields.io/badge/ORCID-Profile-06b6d4?style=flat-square&logo=orcid&logoColor=white&labelColor=1a1a2e)](https://orcid.org/0000-0003-1205-3209)&nbsp;
+[![Google Scholar](https://img.shields.io/badge/Google-Scholar-0ea5e9?style=flat-square&logo=googlescholar&logoColor=white&labelColor=1a1a2e)](https://scholar.google.com/citations?user=Ml95eTwAAAAJ&hl=en)
 
 </div>
 
@@ -115,6 +115,6 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-![](https://capsule-render.vercel.app/api?type=waving&height=80&color=0:22c55e,50:1a1a2e,100:7c3aed&section=footer&reversal=true)
+<img src="https://capsule-render.vercel.app/api?type=waving&height=80&color=0:22c55e,50:1a1a2e,100:7c3aed&section=footer&reversal=true" alt="" aria-hidden="true" />
 
 </div>


### PR DESCRIPTION
### 💡 What:
Updated the `alt` text for two-sided shield status badges in the README and replaced the decorative footer waving image with an explicit, accessible HTML `<img>` tag.

### 🎯 Why:
Generic Markdown `alt` text on two-sided badges (e.g., `![Email]`) meant that screen reader users missed the actual value being linked to (the right side of the badge, e.g., the user's email or username). Decorative images generated with Markdown syntax are also often inconsistently handled by screen readers (sometimes reading the raw URL out loud).

### 📸 Before/After:
*This is a non-visual change for screen readers only.*

### ♿ Accessibility:
- Link badges now accurately describe their destination or value, e.g., `![Email: noah@noahweidig.com]` instead of just `![Email]`.
- The decorative footer image now uses `<img alt="" aria-hidden="true" />` to ensure it is cleanly and consistently skipped by assistive technology.

---
*PR created automatically by Jules for task [7157253286241260089](https://jules.google.com/task/7157253286241260089) started by @noahweidig*