### PR TITLE
🎨 Palette: Improve badge icon contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 
 ![R](https://img.shields.io/badge/R-276DC3?style=flat-square&logo=r&logoColor=white&labelColor=1a1a2e)&nbsp;
 ![Python](https://img.shields.io/badge/Python-3b82f6?style=flat-square&logo=python&logoColor=white&labelColor=1a1a2e)&nbsp;
-![JavaScript](https://img.shields.io/badge/JavaScript-f59e0b?style=flat-square&logo=javascript&logoColor=black&labelColor=1a1a2e)&nbsp;
+![JavaScript](https://img.shields.io/badge/JavaScript-f59e0b?style=flat-square&logo=javascript&logoColor=white&labelColor=1a1a2e)&nbsp;
 ![Bash](https://img.shields.io/badge/Bash-94a3b8?style=flat-square&logo=gnubash&logoColor=white&labelColor=1a1a2e)&nbsp;
 ![HTML5](https://img.shields.io/badge/HTML5-f97316?style=flat-square&logo=html5&logoColor=white&labelColor=1a1a2e)&nbsp;
 ![CSS](https://img.shields.io/badge/CSS-2563eb?style=flat-square&logo=css3&logoColor=white&labelColor=1a1a2e)&nbsp;
 ![LaTeX](https://img.shields.io/badge/LaTeX-64748b?style=flat-square&logo=latex&logoColor=white&labelColor=1a1a2e)&nbsp;
-![Markdown](https://img.shields.io/badge/Markdown-e2e8f0?style=flat-square&logo=markdown&logoColor=black&labelColor=1a1a2e)
+![Markdown](https://img.shields.io/badge/Markdown-e2e8f0?style=flat-square&logo=markdown&logoColor=white&labelColor=1a1a2e)
 
 **GIS & Remote Sensing**
 
@@ -107,7 +107,7 @@ I collaborate on projects that make **landscapes and communities more resilient*
 <br/>
 
 [![Schedule a Meeting](https://img.shields.io/badge/Schedule%20a%20Meeting-7c3aed?style=flat-square&logo=googlecalendar&logoColor=white&labelColor=1a1a2e&color=7c3aed)](https://cal.com/noah-weidig/meet)&nbsp;&nbsp;
-[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-f59e0b?style=flat-square&logo=buymeacoffee&logoColor=black&labelColor=1a1a2e)](https://buymeacoffee.com/noahweidig)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-f59e0b?style=flat-square&logo=buymeacoffee&logoColor=white&labelColor=1a1a2e)](https://buymeacoffee.com/noahweidig)
 
 <br/>
 


### PR DESCRIPTION
### 💡 What:
Updated the URL configuration for the JavaScript, Markdown, and "Buy Me a Coffee" badges in `README.md` to use `logoColor=white` instead of `logoColor=black`.

### 🎯 Why:
The dark background for the icon side of the badges (`labelColor=1a1a2e`) caused black icons (`logoColor=black`) to be completely invisible, making it look like an empty space. Switching to a white logo brings the contrast in line with the other badges on the profile.

### 📸 Before/After:
**Before**: `logoColor=black` on `labelColor=1a1a2e` resulted in a nearly invisible black icon on a dark blue/black background.
**After**: `logoColor=white` on `labelColor=1a1a2e` makes the JavaScript, Markdown, and BMC logos clearly visible.

### ♿ Accessibility:
Improved visual contrast ratio significantly for low-vision users to easily identify the associated platform icons in the skill and footer sections.

---
*PR created automatically by Jules for task [4423626512946362229](https://jules.google.com/task/4423626512946362229) started by @noahweidig*