### PR TITLE
🕵️ Clarity: simplify wildfire damage assessment text

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 
 - Role of Conservation Reserve Program lands in wildfire risk across the Great Plains
 - Large wildfire regime analysis — Great Plains & Eastern Temperate Forests
-- Wildfire damage and destruction assessment to structures
+- Wildfire damage assessment for structures
 
 </td>
 <td width="50%" valign="top">


### PR DESCRIPTION
💡 What: Updated the phrase "Wildfire damage and destruction assessment to structures" to "Wildfire damage assessment for structures".

🎯 Why: The original text was slightly verbose ("damage and destruction" is redundant) and grammatically awkward ("assessment to").

✍️ Result: The updated sentence is more concise, easier to read, and grammatically correct while maintaining the original meaning.

---
*PR created automatically by Jules for task [3296871081052004384](https://jules.google.com/task/3296871081052004384) started by @noahweidig*