### PR TITLE
🎨 Palette: Expand call-to-action click target

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-23 - Fitts's Law in Markdown
+**Learning:** In text-heavy environments like a GitHub README, small link targets (like a bare URL at the end of a sentence) can be hard to tap on mobile devices. Non-clickable context around links is often a missed opportunity for a larger hit area.
+**Action:** When adding call-to-action links with leading text (e.g., "Check out my work -> link.com"), wrap the entire phrase in the link to maximize the clickable area, applying Fitts's Law even to simple text interfaces.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-*Case studies · Maps · Publications &nbsp;→&nbsp; **[noahweidig.com](https://noahweidig.com)***
+_[Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**](https://noahweidig.com)_
 
 <br/>
 


### PR DESCRIPTION
**💡 What**
Expanded the call-to-action link at the bottom of the README from just the URL (`noahweidig.com`) to encompass the entire leading phrase (`Case studies · Maps · Publications → noahweidig.com`).

**🎯 Why**
Following Fitts's Law, larger targets are faster and easier to click. By making the descriptive text part of the link itself, the clickable area is significantly increased. This makes the CTA more obvious and much easier to tap, especially on mobile devices.

**📸 Before/After**
Before: *Case studies · Maps · Publications → **[noahweidig.com](https://noahweidig.com)***
After: _[Case studies · Maps · Publications → **noahweidig.com**](https://noahweidig.com)_

**♿ Accessibility**
Provides a much larger hit area for users with motor impairments or those using touch interfaces, making the primary call-to-action more accessible and reducing accidental misclicks.

---
*PR created automatically by Jules for task [12558042506510111781](https://jules.google.com/task/12558042506510111781) started by @noahweidig*