### PR TITLE
👁️ Focus: highlight primary portfolio CTA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-_[Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**](https://noahweidig.com)_
+<kbd>_[Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**](https://noahweidig.com)_</kbd>
 
 <br/>
 


### PR DESCRIPTION
* 💡 **What**: Wrapped the main call-to-action link (`noahweidig.com` portfolio) at the bottom of `README.md` in a `<kbd>` element.
* 🎯 **Why**: The link was previously simple italicized text that blended in with the surrounding spacing and footer image. By using `<kbd>`, it gains a subtle border and shadow in GitHub Flavored Markdown, effectively drawing attention to the most important conversion point.
* ♿ **Accessibility**: The `<kbd>` tag does not interfere with screen readers interpreting the inner text or the link itself. It operates mostly visually within GitHub's renderer.
* 📸 **Before/After**: The text changed from standard italics to a button-like badge format.

---
*PR created automatically by Jules for task [10195489367375151102](https://jules.google.com/task/10195489367375151102) started by @noahweidig*