### PR TITLE
🎨 Palette: [UX improvement] Maximize hit area for kbd button links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 ## 2024-05-23 - Fitts's Law in Markdown
 **Learning:** In text-heavy environments like a GitHub README, small link targets (like a bare URL at the end of a sentence) can be hard to tap on mobile devices. Non-clickable context around links is often a missed opportunity for a larger hit area.
 **Action:** When adding call-to-action links with leading text (e.g., "Check out my work -> link.com"), wrap the entire phrase in the link to maximize the clickable area, applying Fitts's Law even to simple text interfaces.
+
+## 2024-05-24 - Maximizing Clickable Hit Areas for UI Elements in Markdown
+**Learning:** In GitHub Flavored Markdown, using `<kbd>` tags for visual styling creates a button-like boundary, but if the `<kbd>` tag is on the outside of a link (`<kbd>[Text](url)</kbd>`), only the text inside acts as the clickable hit target, ignoring the padding of the `<kbd>` container.
+**Action:** Always place `<kbd>` styling tags *inside* Markdown links (`[<kbd>Text</kbd>](url)`). This ensures the entire visual area, including padding, is clickable, significantly improving the interactive footprint for both mobile taps and mouse clicks without any custom CSS.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-<kbd>_[Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**](https://noahweidig.com)_</kbd>
+[<kbd>_Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**_</kbd>](https://noahweidig.com)
 
 <br/>
 


### PR DESCRIPTION
### 💡 What
Updated the markdown link syntax for the primary Call-To-Action at the bottom of the README.

### 🎯 Why
Previously, the `[Link](url)` syntax was inside the `<kbd>` tag. In GitHub Flavored Markdown, this makes only the *text* clickable, while ignoring the padding and visual boundary of the `<kbd>` element. By wrapping the `<kbd>` tag inside the link (`[<kbd>Link</kbd>](url)`), the entire visual footprint becomes the clickable hit area. This applies Fitts's Law to a simple text interface, making it significantly easier to tap on mobile devices or click on desktop.

### 📸 Before/After
- **Before:** `<kbd>_[Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**](https://noahweidig.com)_</kbd>` (only text is clickable)
- **After:** `[<kbd>_Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**_</kbd>](https://noahweidig.com)` (entire button boundary is clickable)

### ♿ Accessibility
Improved usability by increasing the target size of a key interactive element, which is particularly helpful for users with motor impairments or those on touch devices where precise tapping is difficult.

Also updated `.Jules/palette.md` to record this specific Markdown interaction learning.

---
*PR created automatically by Jules for task [11292444905037323176](https://jules.google.com/task/11292444905037323176) started by @noahweidig*