### PR TITLE
🎨 Palette: [UX improvement] Add native hover tooltips to README badges

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2024-05-24 - Maximizing Clickable Hit Areas for UI Elements in Markdown
 **Learning:** In GitHub Flavored Markdown, using `<kbd>` tags for visual styling creates a button-like boundary, but if the `<kbd>` tag is on the outside of a link (`<kbd>[Text](url)</kbd>`), only the text inside acts as the clickable hit target, ignoring the padding of the `<kbd>` container.
 **Action:** Always place `<kbd>` styling tags *inside* Markdown links (`[<kbd>Text</kbd>](url)`). This ensures the entire visual area, including padding, is clickable, significantly improving the interactive footprint for both mobile taps and mouse clicks without any custom CSS.
+
+## 2024-05-25 - Native Tooltips on Markdown Badges
+**Learning:** Icon-only or badge-style links in a GitHub README often lack context about their destination or function. Since custom CSS and JavaScript are sanitized, traditional tooltips are unavailable, but the native Markdown `title` attribute on links provides an elegant, accessible alternative to improve confidence before clicking.
+**Action:** Always add descriptive `title` attributes using the Markdown link syntax (`[alt](url "Tooltip description")`) on image-based or abbreviated links in READMEs to create native hover tooltips and enhance context.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ If Earth has a pattern, I want to find it.</em></p>
 
 <br/>
 
-[![Email: noah@noahweidig.com](https://img.shields.io/badge/Email-noah%40noahweidig.com-7c3aed?style=flat-square&logo=minutemailer&logoColor=white&labelColor=1a1a2e)](mailto:noah@noahweidig.com)&nbsp;
-[![Website: noahweidig.com](https://img.shields.io/badge/Website-noahweidig.com-6d28d9?style=flat-square&logo=safari&logoColor=white&labelColor=1a1a2e)](https://noahweidig.com)&nbsp;
-[![Substack Newsletter](https://img.shields.io/badge/Substack-Newsletter-4f46e5?style=flat-square&logo=substack&logoColor=white&labelColor=1a1a2e)](https://noahweidig.substack.com/)&nbsp;
-[![LinkedIn Profile](https://img.shields.io/badge/LinkedIn-Profile-2563eb?style=flat-square&logo=linkedin&logoColor=white&labelColor=1a1a2e)](https://www.linkedin.com/in/noahweidig/)&nbsp;
-[![ORCID Profile](https://img.shields.io/badge/ORCID-Profile-06b6d4?style=flat-square&logo=orcid&logoColor=white&labelColor=1a1a2e)](https://orcid.org/0000-0003-1205-3209)&nbsp;
-[![Google Scholar](https://img.shields.io/badge/Google-Scholar-0ea5e9?style=flat-square&logo=googlescholar&logoColor=white&labelColor=1a1a2e)](https://scholar.google.com/citations?user=Ml95eTwAAAAJ&hl=en)
+[![Email: noah@noahweidig.com](https://img.shields.io/badge/Email-noah%40noahweidig.com-7c3aed?style=flat-square&logo=minutemailer&logoColor=white&labelColor=1a1a2e)](mailto:noah@noahweidig.com "Send me an email")&nbsp;
+[![Website: noahweidig.com](https://img.shields.io/badge/Website-noahweidig.com-6d28d9?style=flat-square&logo=safari&logoColor=white&labelColor=1a1a2e)](https://noahweidig.com "Visit my website")&nbsp;
+[![Substack Newsletter](https://img.shields.io/badge/Substack-Newsletter-4f46e5?style=flat-square&logo=substack&logoColor=white&labelColor=1a1a2e)](https://noahweidig.substack.com/ "Read my Substack newsletter")&nbsp;
+[![LinkedIn Profile](https://img.shields.io/badge/LinkedIn-Profile-2563eb?style=flat-square&logo=linkedin&logoColor=white&labelColor=1a1a2e)](https://www.linkedin.com/in/noahweidig/ "Connect with me on LinkedIn")&nbsp;
+[![ORCID Profile](https://img.shields.io/badge/ORCID-Profile-06b6d4?style=flat-square&logo=orcid&logoColor=white&labelColor=1a1a2e)](https://orcid.org/0000-0003-1205-3209 "View my ORCID profile")&nbsp;
+[![Google Scholar](https://img.shields.io/badge/Google-Scholar-0ea5e9?style=flat-square&logo=googlescholar&logoColor=white&labelColor=1a1a2e)](https://scholar.google.com/citations?user=Ml95eTwAAAAJ&hl=en "View my Google Scholar profile")
 
 </div>
 
@@ -106,8 +106,8 @@ I collaborate on projects that make **landscapes and communities more resilient*
 
 <br/>
 
-[![Schedule a Meeting](https://img.shields.io/badge/Schedule%20a%20Meeting-7c3aed?style=flat-square&logo=googlecalendar&logoColor=white&labelColor=1a1a2e&color=7c3aed)](https://cal.com/noah-weidig/meet)&nbsp;&nbsp;
-[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-f59e0b?style=flat-square&logo=buymeacoffee&logoColor=white&labelColor=1a1a2e)](https://buymeacoffee.com/noahweidig)
+[![Schedule a Meeting](https://img.shields.io/badge/Schedule%20a%20Meeting-7c3aed?style=flat-square&logo=googlecalendar&logoColor=white&labelColor=1a1a2e&color=7c3aed)](https://cal.com/noah-weidig/meet "Book a meeting with me")&nbsp;&nbsp;
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-f59e0b?style=flat-square&logo=buymeacoffee&logoColor=white&labelColor=1a1a2e)](https://buymeacoffee.com/noahweidig "Support my work")
 
 <br/>
 


### PR DESCRIPTION
**💡 What:**
Added native Markdown title attributes to the primary contact and social badge links in the `README.md` file, creating native hover tooltips. Also recorded a journal entry about this UX insight in `.Jules/palette.md`.

**🎯 Why:**
Icon-only or badge-style links in a GitHub README often lack context about their exact destination or function until clicked. Since custom CSS and JavaScript are sanitized on GitHub profiles, traditional tooltips are unavailable. The native Markdown `title` attribute on links provides an elegant, accessible alternative to improve confidence before a user decides to click on a badge.

**📸 Before/After:**
*(Visual change only observable on hover: hovering over a badge now displays a native browser tooltip like "Send me an email", "Connect with me on LinkedIn", etc.)*

**♿ Accessibility:**
This change leverages standard semantic HTML attributes (via Markdown compilation to the `<a>` tag's `title` attribute). This provides explicit destination context to users without modifying the visual layout, aiding cognitive accessibility and providing clarity for users navigating by pointing devices.

---
*PR created automatically by Jules for task [12616428760958040540](https://jules.google.com/task/12616428760958040540) started by @noahweidig*