### PR TITLE
🔗 Consistency: [unified label for Google Scholar]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If Earth has a pattern, I want to find it.</em></p>
 [![Substack Newsletter](https://img.shields.io/badge/Substack-Newsletter-4f46e5?style=flat-square&logo=substack&logoColor=white&labelColor=1a1a2e)](https://noahweidig.substack.com/ "Read my Substack newsletter")&nbsp;
 [![LinkedIn Profile](https://img.shields.io/badge/LinkedIn-Profile-2563eb?style=flat-square&logo=linkedin&logoColor=white&labelColor=1a1a2e)](https://www.linkedin.com/in/noahweidig/ "Connect with me on LinkedIn")&nbsp;
 [![ORCID Profile](https://img.shields.io/badge/ORCID-Profile-06b6d4?style=flat-square&logo=orcid&logoColor=white&labelColor=1a1a2e)](https://orcid.org/0000-0003-1205-3209 "View my ORCID profile")&nbsp;
-[![Google Scholar](https://img.shields.io/badge/Google-Scholar-0ea5e9?style=flat-square&logo=googlescholar&logoColor=white&labelColor=1a1a2e)](https://scholar.google.com/citations?user=Ml95eTwAAAAJ&hl=en "View my Google Scholar profile")
+[![Google Scholar Profile](https://img.shields.io/badge/Google%20Scholar-Profile-0ea5e9?style=flat-square&logo=googlescholar&logoColor=white&labelColor=1a1a2e)](https://scholar.google.com/citations?user=Ml95eTwAAAAJ&hl=en "View my Google Scholar profile")
 
 </div>
 


### PR DESCRIPTION
### 💡 What
Unified the label and alt text for the Google Scholar badge.

### 🎯 Why
The other profile badges (LinkedIn and ORCID) used the format "[Platform] | Profile" (e.g., `LinkedIn | Profile`, `ORCID | Profile`). The Google Scholar badge was formatted as `Google | Scholar`. Updating it to `Google Scholar | Profile` aligns it with the rest of the profile badges, improving visual consistency. The markdown alt text was also updated to "Google Scholar Profile" to match.

### 📸 Before/After
**Before:**
`Google | Scholar`

**After:**
`Google Scholar | Profile`

### ✍️ Result
A smoother, more predictable user experience with consistent badge labeling across all profiles.

---
*PR created automatically by Jules for task [4932369287167161907](https://jules.google.com/task/4932369287167161907) started by @noahweidig*