### PR TITLE
🎨 Palette: [Add native hover tooltips to primary CTAs]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Banner Image Accessibility
 **Learning:** In Markdown, banner or structural images wrapped in hyperlinks must have descriptive alt text. Without it, screen readers will announce the raw destination URL or treat it as an empty link, obscuring the primary navigation path.
 **Action:** Always ensure images wrapped in anchor tags have descriptive `alt` text to provide context for screen readers.
+
+## 2024-05-25 - Native Hover Tooltips for CTAs
+**Learning:** In GitHub Markdown, adding a `title` attribute to `<a>` tags or using the native title syntax (`[Text](url "Tooltip Title")`) provides native hover tooltips. This is critical for improving accessibility, predictability, and user context without relying on custom CSS or JavaScript, particularly for primary Call-to-Action links and banner images.
+**Action:** Always include descriptive tooltips using the native markdown syntax (`title` attr or `"Tooltip Title"`) for main navigation links and primary interactive elements in Markdown profiles.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ⚡ Bolt Optimization: Converted PNG banner (498KB) to WebP (33KB) to reduce image payload by ~93% -->
-<a href="https://noahweidig.com" target="_blank">
+<a href="https://noahweidig.com" target="_blank" title="Visit noahweidig.com (Opens in a new tab)">
   <img src="github-banner.webp" width="100%" alt="Noah Weidig - Portfolio and Projects" />
 </a>
 
@@ -110,7 +110,7 @@ I collaborate on projects that build **resilient landscapes and communities** th
 
 <br/>
 
-[<kbd>_Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**_</kbd>](https://noahweidig.com)
+[<kbd>_Case studies · Maps · Publications &nbsp;→&nbsp; **noahweidig.com**_</kbd>](https://noahweidig.com "View my full portfolio at noahweidig.com")
 
 <br/>
 


### PR DESCRIPTION
### 💡 What
Added native hover tooltips (`title` attributes) to the top banner link and the primary bottom Call-To-Action (CTA) link in `README.md`. 

### 🎯 Why
Tooltips provide immediate, contextual feedback to users about where a link will take them or what action it will perform before they click it. This simple addition creates a more predictable and user-friendly experience, particularly for primary navigation elements.

### 📸 Before/After
* **Before:** Hovering over the top banner or bottom CTA link showed only the default browser URL preview in the status bar.
* **After:** Hovering over these elements now displays a helpful native tooltip (e.g., "Visit noahweidig.com (Opens in a new tab)" or "View my full portfolio at noahweidig.com").

### ♿ Accessibility
Native tooltips (`title` attributes in HTML and Markdown) improve accessibility by providing extra context. This is especially helpful for users who may need clarification on a link's destination or behavior (like opening a new tab), creating a more inclusive and informative browsing experience.

---
*PR created automatically by Jules for task [2335904224463069118](https://jules.google.com/task/2335904224463069118) started by @noahweidig*