### PR TITLE
🎨 Palette: Convert faux headings to semantic structure

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - Native Hover Tooltips for CTAs
 **Learning:** In GitHub Markdown, adding a `title` attribute to `<a>` tags or using the native title syntax (`[Text](url "Tooltip Title")`) provides native hover tooltips. This is critical for improving accessibility, predictability, and user context without relying on custom CSS or JavaScript, particularly for primary Call-to-Action links and banner images.
 **Action:** Always include descriptive tooltips using the native markdown syntax (`title` attr or `"Tooltip Title"`) for main navigation links and primary interactive elements in Markdown profiles.
+
+## 2024-05-26 - Semantic HTML over Visual Faux Headings
+**Learning:** Using bold text (`**Text**`) for visual separation creates a faux heading that screen readers cannot identify. True semantic headings (e.g., `#### Text`) provide navigational structure and context for assistive technologies.
+**Action:** Always use proper markdown heading syntax instead of bold text for document structure and section titles.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 <tr>
 <td width="50%" valign="top">
 
-**🔥 Wildfire & Conservation**
+#### 🔥 Wildfire & Conservation
 
 - Role of Conservation Reserve Program lands in wildfire risk across the Great Plains
 - Large wildfire regime analysis — Great Plains & Eastern Temperate Forests
@@ -49,7 +49,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 </td>
 <td width="50%" valign="top">
 
-**🗺️ Geospatial Tools & Data**
+#### 🗺️ Geospatial Tools & Data
 
 - Curating US Census TIGER Roads in Google Earth Engine
 - Building geospatial data products for conservation decision-making
@@ -63,7 +63,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 
 ### ⚙️ &nbsp;Stack
 
-**Languages**
+#### Languages
 
 ![R](https://img.shields.io/badge/R-276DC3?style=flat-square&logo=r&logoColor=white&labelColor=1a1a2e "R")&nbsp;
 ![Python](https://img.shields.io/badge/Python-3b82f6?style=flat-square&logo=python&logoColor=white&labelColor=1a1a2e "Python")&nbsp;
@@ -74,7 +74,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 ![LaTeX](https://img.shields.io/badge/LaTeX-64748b?style=flat-square&logo=latex&logoColor=white&labelColor=1a1a2e "LaTeX")&nbsp;
 ![Markdown](https://img.shields.io/badge/Markdown-e2e8f0?style=flat-square&logo=markdown&logoColor=white&labelColor=1a1a2e "Markdown")
 
-**GIS & Remote Sensing**
+#### GIS & Remote Sensing
 
 ![Earth Engine](https://img.shields.io/badge/Earth%20Engine-4285F4?style=flat-square&logo=googleearthengine&logoColor=white&labelColor=1a1a2e "Google Earth Engine")&nbsp;
 ![ArcGIS](https://img.shields.io/badge/ArcGIS-2C7AC3?style=flat-square&logo=arcgis&logoColor=white&labelColor=1a1a2e "ArcGIS")&nbsp;
@@ -84,7 +84,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 ![MapLibre](https://img.shields.io/badge/MapLibre-4f46e5?style=flat-square&logo=maplibre&logoColor=white&labelColor=1a1a2e "MapLibre")&nbsp;
 ![Leaflet](https://img.shields.io/badge/Leaflet-0ea5e9?style=flat-square&logo=leaflet&logoColor=white&labelColor=1a1a2e "Leaflet")
 
-**Data & Dev**
+#### Data & Dev
 
 ![RStudio](https://img.shields.io/badge/RStudio-75AADB?style=flat-square&logo=rstudioide&logoColor=white&labelColor=1a1a2e "RStudio")&nbsp;
 ![Tidyverse](https://img.shields.io/badge/Tidyverse-7c3aed?style=flat-square&logo=tidyverse&logoColor=white&labelColor=1a1a2e "Tidyverse")&nbsp;


### PR DESCRIPTION
### 💡 What
Converted visual faux headings (bold text like `**Languages**`) into true semantic markdown headings (`#### Languages`) across the `README.md` profile layout.

### 🎯 Why
Screen readers use heading tags (`<h1>` to `<h6>`) to generate an outline of the page, allowing users to jump directly to sections of interest. Using bold text for visual separation creates a "faux heading" that looks like a section title but is invisible to assistive technologies as a structural element. 

### ♿ Accessibility
- Improves document outline navigation for screen reader users.
- Ensures heading hierarchy is maintained (nesting `####` under `###`).
- Follows the WCAG standard for info and relationships (SC 1.3.1), ensuring that structure conveyed visually is also available programmatically.

The UX insight regarding semantic HTML over visual faux headings was also documented in the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [8064385614116299984](https://jules.google.com/task/8064385614116299984) started by @noahweidig*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added guidance on using semantic HTML headings instead of bold text for proper document structure.
* Improved documentation formatting by converting section titles to proper markdown headers for enhanced readability and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->