### PR TITLE
🎨 Palette: Update banner alt text to match embedded image text

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-20 - Markdown Aria-Hidden Limitation
+**Learning:** GitHub's markdown parser sanitizes `aria-hidden` attributes on inline HTML elements, making it ineffective for hiding decorative text or emojis. However, for structural banner/footer images like `<img>`, empty `alt=""` is standard for decorative images, but when it's just an `<img>` tag without a link, it's decorative anyway.
+**Action:** Use standard empty `alt=""` for decorative images instead of relying solely on `aria-hidden` which may be stripped.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- ⚡ Bolt Optimization: Converted PNG banner (498KB) to WebP (33KB) to reduce image payload by ~93% -->
 <a href="https://noahweidig.com" target="_blank" title="Visit noahweidig.com (Opens in a new tab)">
-  <img src="github-banner.webp" width="100%" alt="Noah Weidig - Portfolio and Projects" />
+  <img src="github-banner.webp" width="100%" alt="Noah Weidig - GIS & Data Scientist" />
 </a>
 
 <br>


### PR DESCRIPTION
### 💡 What
Updated the `alt` text of the banner image in `README.md` from `"Noah Weidig - Portfolio and Projects"` to `"Noah Weidig - GIS & Data Scientist"`.

### 🎯 Why
To comply with WCAG 1.1.1 (Non-text Content), the `alt` text of an informative/functional image should accurately reflect any text embedded within it. The image visually displays "Noah Weidig - GIS & Data Scientist", but previously the `alt` text described it as a portfolio. Updating the `alt` text ensures that screen reader users receive the exact same specific context as sighted users. Since the image is wrapped in a link, this also improves the accessible name of the link.

### 📸 Before/After
**Before:**
`<img src="github-banner.webp" width="100%" alt="Noah Weidig - Portfolio and Projects" />`

**After:**
`<img src="github-banner.webp" width="100%" alt="Noah Weidig - GIS & Data Scientist" />`

### ♿ Accessibility
- Provides an accurate programmatic equivalent to visually embedded text.
- Improves the accessible name of the wrapping destination link (`<a>`).

---
*PR created automatically by Jules for task [8970393594012553186](https://jules.google.com/task/8970393594012553186) started by @noahweidig*