### PR TITLE
🎨 Palette: Align alt text with burned-in text

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-20 - Markdown Aria-Hidden Limitation
 **Learning:** GitHub's markdown parser sanitizes `aria-hidden` attributes on inline HTML elements, making it ineffective for hiding decorative text or emojis. However, for structural banner/footer images like `<img>`, empty `alt=""` is standard for decorative images, but when it's just an `<img>` tag without a link, it's decorative anyway.
 **Action:** Use standard empty `alt=""` for decorative images instead of relying solely on `aria-hidden` which may be stripped.
+## 2024-03-22 - Aligning Alt Text with Burned-in Image Text
+**Learning:** For Markdown images containing explicit burned-in text (like SVG badges), the markdown `alt` text (`![alt](url)`) must match or contain the visible text to satisfy WCAG 1.1.1 (Non-text Content) and WCAG 2.5.3 (Label in Name). If a badge visibly reads "MEET WITH ME" or "OSM", providing generic or interpretive alt text like "Schedule a Meeting" or "OpenStreetMap" creates a mismatch for speech-input users and screen reader parity.
+**Action:** Always ensure markdown `alt` text reflects the exact burned-in text of the image. Supplemental context can still be provided in the native markdown tooltip (e.g., `![OSM](url "OpenStreetMap")`).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 ![Earth Engine](icons/badge-earth-engine.svg "Google Earth Engine")&nbsp;
 ![ArcGIS](icons/badge-arcgis.svg "ArcGIS")&nbsp;
 ![GDAL](icons/badge-gdal.svg "GDAL")&nbsp;
-![OpenStreetMap](icons/badge-osm.svg "OpenStreetMap")&nbsp;
+![OSM](icons/badge-osm.svg "OpenStreetMap")&nbsp;
 ![Mapbox](icons/badge-mapbox.svg "Mapbox")&nbsp;
 ![MapLibre](icons/badge-maplibre.svg "MapLibre")&nbsp;
 ![Leaflet](icons/badge-leaflet.svg "Leaflet")
@@ -75,7 +75,7 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 ![NumPy](icons/badge-numpy.svg "NumPy")&nbsp;
 ![Jupyter](icons/badge-jupyter.svg "Jupyter")&nbsp;
 ![Quarto](icons/badge-quarto.svg "Quarto")&nbsp;
-![GitHub Actions](icons/badge-actions.svg "GitHub Actions")&nbsp;
+![Actions](icons/badge-actions.svg "GitHub Actions")&nbsp;
 ![Git](icons/badge-git.svg "Git")
 
 ---
@@ -90,7 +90,7 @@ I collaborate on projects that build **resilient landscapes and communities** th
 
 <!-- ⚡ Bolt Optimization: Hosted custom-icon-badges SVGs locally to eliminate 3rd-party network requests and DNS/TLS overhead -->
 
-[![Schedule a Meeting](icons/badge-meet.svg)](https://cal.com/noah-weidig/meet "Book a meeting with me")&nbsp;&nbsp;
+[![MEET WITH ME](icons/badge-meet.svg)](https://cal.com/noah-weidig/meet "Book a meeting with me")&nbsp;&nbsp;
 [![Buy Me a Coffee](icons/badge-coffee.svg)](https://buymeacoffee.com/noahweidig "Support my work")
 
 <br/>


### PR DESCRIPTION
## 💡 What
Updated the markdown `alt` text for three SVG badges (`badge-actions`, `badge-osm`, `badge-meet`) to perfectly match the explicit text burned visually into the badges. Supplemental context is preserved in the native markdown hover tooltip using the `![alt](url "Title")` syntax.

## 🎯 Why
When an image contains explicit burned-in text, providing a generic or interpretive description (e.g., using "Schedule a Meeting" when the badge visibly says "MEET WITH ME") creates a mismatch for users navigating via speech-input software or screen readers.

## ♿ Accessibility
- **WCAG 1.1.1 (Non-text Content):** Ensures text alternatives provide an equivalent experience to the visual presentation.
- **WCAG 2.5.3 (Label in Name):** Ensures that the accessible name (alt text) contains the visible text, allowing speech-input users to activate elements by dictating what they physically see on the screen.

## 📸 Before/After
*(Visuals remain identical, accessible markup changed)*
**Before:** `![OpenStreetMap](icons/badge-osm.svg "OpenStreetMap")`
**After:** `![OSM](icons/badge-osm.svg "OpenStreetMap")`

---
*PR created automatically by Jules for task [16220272630482947840](https://jules.google.com/task/16220272630482947840) started by @noahweidig*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance on image alt text requirements to match visible text content.

* **Style**
  * Updated README badge labels and call-to-action text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->