### PR TITLE
Fix render-readme workflow and stats card light/dark rendering

### DIFF
--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -44,10 +44,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p _site
+          cp index.html _site/index.html
+
       - name: Upload to Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'index.html'
+          path: '_site'
 
   deploy:
     environment:

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 </p>
 
 <p>
-  <img src="https://github.com/noahweidig/github-stats/blob/generated/overview.svg#gh-dark-mode-only" width="360">
-  <img src="https://github.com/noahweidig/github-stats/blob/generated/languages.svg#gh-dark-mode-only" width="360">
+  <img src="https://github.com/noahweidig/github-stats/blob/generated/overview.svg" width="360">
+  <img src="https://github.com/noahweidig/github-stats/blob/generated/languages.svg" width="360">
 </p>
 
 ---

--- a/index.html
+++ b/index.html
@@ -356,8 +356,8 @@
   <img src="./profile-3d-contrib/profile-night-rainbow.svg" alt="3D GitHub contribution graph">
 </p>
 <p>
-  <img src="https://github.com/noahweidig/github-stats/blob/generated/overview.svg#gh-dark-mode-only" width="360">
-  <img src="https://github.com/noahweidig/github-stats/blob/generated/languages.svg#gh-dark-mode-only" width="360">
+  <img src="https://github.com/noahweidig/github-stats/blob/generated/overview.svg" width="360">
+  <img src="https://github.com/noahweidig/github-stats/blob/generated/languages.svg" width="360">
 </p>
 <hr>
 <h3>🤝  Let’s Work Together</h3>


### PR DESCRIPTION
## Summary
- `upload-pages-artifact@v3` was passed `path: index.html` (a file), but it requires a directory — `tar` failed with `Cannot open: Not a directory`, which was the workflow's actual failure. Fixed by copying the rendered file into a `_site/` directory before upload.
- The GitHub stats cards in the README used `#gh-dark-mode-only`, but `noahweidig/github-stats` only publishes one self-adapting SVG per chart (it uses `prefers-color-scheme` internally). The fragment hid the images entirely in light mode on GitHub and had no effect in the rendered `index.html`. Removed the fragment so the cards render correctly in both light and dark, and in both the Markdown README and the generated HTML.

## Test plan
- [x] `npm ci && node scripts/render-readme.js` runs cleanly
- [x] Simulated the Pages artifact `tar` step locally against `_site/` — succeeds
- [ ] Confirm the `render` workflow run is green on this branch/PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SviaSknHeT6TPQHjc5ds1y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated contribution, language, and GitHub statistics visuals so they display consistently across light and dark themes.
  * Improved website publishing so the rendered page is packaged and deployed correctly to GitHub Pages.
* **Documentation**
  * Refreshed the README and site visuals to use theme-independent image sources, ensuring the displayed statistics remain visible regardless of viewing mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->