### PR TITLE
Move GitHub stats SVG generation into this repo (auto light/dark)

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -1,0 +1,46 @@
+name: Generate Stats Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/generate-stats.js'
+      - 'scripts/templates/**'
+      - '.github/workflows/github-stats.yml'
+  schedule:
+    - cron: '5 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate images
+        run: node scripts/generate-stats.js
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXCLUDE_REPOS: ${{ secrets.EXCLUDE_REPOS }}
+          EXCLUDE_LANGS: ${{ secrets.EXCLUDE_LANGS }}
+          EXCLUDE_PRIVATE: 'false'
+          MAX_RETRIES: 5
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats
+          git diff --quiet && git diff --staged --quiet \
+            || (git commit -m "chore: update GitHub stats images" && git push)

--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -8,6 +8,8 @@ on:
       - 'README.md'
       - 'icons/**'
       - 'github-banner.webp'
+      - 'stats/**'
+      - 'profile-3d-contrib/**'
       - '.github/workflows/render-readme.yml'
   workflow_dispatch:
 
@@ -48,6 +50,8 @@ jobs:
         run: |
           mkdir -p _site
           cp index.html _site/index.html
+          cp -r icons stats profile-3d-contrib _site/
+          cp github-banner.webp _site/
 
       - name: Upload to Pages
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ GIS analyst and data scientist at the intersection of **remote sensing**, **cons
 </p>
 
 <p>
-  <img src="https://github.com/noahweidig/github-stats/blob/generated/overview.svg" width="360">
-  <img src="https://github.com/noahweidig/github-stats/blob/generated/languages.svg" width="360">
+  <img src="./stats/overview.svg" width="360" alt="GitHub statistics overview">
+  <img src="./stats/languages.svg" width="360" alt="Languages used by file size">
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Personal portfolio and README renderer",
   "scripts": {
-    "render": "node scripts/render-readme.js"
+    "render": "node scripts/render-readme.js",
+    "stats": "node scripts/generate-stats.js"
   },
   "dependencies": {
     "markdown-it": "^15.0.0"

--- a/scripts/generate-stats.js
+++ b/scripts/generate-stats.js
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Generate GitHub statistics cards (overview.svg + languages.svg).
+ *
+ * Ported from the Zig implementation in noahweidig/github-stats, which is
+ * itself based on jstrieb/github-stats (MIT). The cards now use a single
+ * `prefers-color-scheme` aware SVG each instead of separate light/dark files.
+ *
+ * Environment variables:
+ *   ACCESS_TOKEN     GitHub token (falls back to GITHUB_TOKEN)
+ *   EXCLUDE_REPOS    comma/space separated glob patterns of repos to skip
+ *   EXCLUDE_LANGS    comma separated language names to skip
+ *   EXCLUDE_PRIVATE  "true" to omit private repositories
+ *   OUTPUT_DIR       output directory (default: stats)
+ *   MAX_RETRIES      retries against the contributors API (default: 5)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const os = require('os');
+
+const TOKEN = process.env.ACCESS_TOKEN || process.env.GITHUB_TOKEN;
+const OUTPUT_DIR = process.env.OUTPUT_DIR || path.join(__dirname, '..', 'stats');
+const TEMPLATE_DIR = path.join(__dirname, 'templates');
+const MAX_RETRIES = Number(process.env.MAX_RETRIES ?? 5);
+const EXCLUDE_PRIVATE = /^true$/i.test(process.env.EXCLUDE_PRIVATE || '');
+const EXCLUDE_REPOS = splitList(process.env.EXCLUDE_REPOS, /[\s,|"']+/);
+const EXCLUDE_LANGS = splitList(process.env.EXCLUDE_LANGS, /[,\t\r\n|"']+/);
+
+if (!TOKEN) {
+  console.error('ACCESS_TOKEN (or GITHUB_TOKEN) must be set.');
+  process.exit(1);
+}
+
+function splitList(value, separator) {
+  if (!value) return [];
+  return value.split(separator).map((s) => s.trim()).filter(Boolean);
+}
+
+/** Translate a shell-style glob into a regular expression. */
+function globToRegExp(pattern) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+function matchAny(patterns, name) {
+  return patterns.some((pattern) => globToRegExp(pattern).test(name));
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function request(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'noahweidig-github-stats',
+      ...(options.headers || {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body };
+}
+
+async function graphql(query, variables) {
+  const { status, body } = await request('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (status !== 200 || !body || body.errors) {
+    throw new Error(
+      `GraphQL request failed (${status}): ${JSON.stringify(body?.errors ?? body)}`,
+    );
+  }
+  return body.data;
+}
+
+async function getBasicInfo() {
+  const data = await graphql(`query {
+    viewer {
+      login
+      name
+      contributionsCollection { contributionYears }
+    }
+  }`);
+  const viewer = data.viewer;
+
+  let emails = [];
+  const response = await request('https://api.github.com/user/emails');
+  if (response.status === 200 && Array.isArray(response.body)) {
+    emails = response.body.map((e) => e.email).filter(Boolean);
+  } else {
+    console.warn('Could not read user emails; token may lack `user:email`.');
+  }
+  if (emails.length === 0) {
+    emails = [`${viewer.login}@users.noreply.github.com`];
+  }
+
+  return {
+    user: viewer.login,
+    name: viewer.name || viewer.login,
+    years: viewer.contributionsCollection.contributionYears,
+    emails,
+  };
+}
+
+const REPOS_QUERY = `query ($from: DateTime, $to: DateTime) {
+  viewer {
+    contributionsCollection(from: $from, to: $to) {
+      totalRepositoryContributions
+      totalIssueContributions
+      totalCommitContributions
+      totalPullRequestContributions
+      totalPullRequestReviewContributions
+      commitContributionsByRepository(maxRepositories: 100) {
+        repository {
+          nameWithOwner
+          stargazerCount
+          forkCount
+          isPrivate
+          languages(first: 100, orderBy: { direction: DESC, field: SIZE }) {
+            edges { size node { name color } }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+function isoDate(year, month) {
+  const y = year + Math.floor(month / 12);
+  const m = (month % 12) + 1;
+  return `${y}-${String(m).padStart(2, '0')}-01T00:00:00Z`;
+}
+
+async function getReposByYear(state, year, startMonth, months) {
+  const data = await graphql(REPOS_QUERY, {
+    from: isoDate(year, startMonth),
+    to: isoDate(year, startMonth + months),
+  });
+  const stats = data.viewer.contributionsCollection;
+  const contributions = stats.commitContributionsByRepository;
+
+  // GitHub caps the response at 100 repositories, so subdivide the window
+  // when we hit the limit to avoid silently dropping data.
+  if (contributions.length >= 100) {
+    for (const factor of [2, 3]) {
+      if (months % factor === 0) {
+        for (let i = 0; i < factor; i += 1) {
+          await getReposByYear(
+            state, year, startMonth + (months / factor) * i, months / factor,
+          );
+        }
+        return;
+      }
+    }
+    console.warn(
+      `More than 100 repos returned for ${startMonth + 1}/${year}; ` +
+      'some data may be omitted due to GitHub API limitations.',
+    );
+  }
+
+  state.contributions += stats.totalRepositoryContributions
+    + stats.totalIssueContributions
+    + stats.totalCommitContributions
+    + stats.totalPullRequestContributions
+    + stats.totalPullRequestReviewContributions;
+
+  for (const { repository: raw } of contributions) {
+    if (state.seen.has(raw.nameWithOwner)) continue;
+    state.seen.add(raw.nameWithOwner);
+
+    const repository = {
+      name: raw.nameWithOwner,
+      stars: raw.stargazerCount,
+      forks: raw.forkCount,
+      private: raw.isPrivate,
+      languages: (raw.languages?.edges ?? []).map((edge) => ({
+        name: edge.node.name,
+        size: edge.size,
+        color: edge.node.color,
+      })),
+      views: 0,
+      lines_changed: 0,
+    };
+
+    const views = await request(
+      `https://api.github.com/repos/${raw.nameWithOwner}/traffic/views`,
+    );
+    if (views.status === 200 && views.body) {
+      repository.views = views.body.count ?? 0;
+    }
+
+    state.repositories.push(repository);
+  }
+}
+
+/** Lines changed by `user` according to the contributor statistics API. */
+async function fetchLinesChanged(repository, user) {
+  const { status, body } = await request(
+    `https://api.github.com/repos/${repository.name}/stats/contributors`,
+  );
+  if (status === 200 && Array.isArray(body)) {
+    let total = 0;
+    for (const author of body) {
+      if (author?.author?.login !== user) continue;
+      for (const week of author.weeks ?? []) {
+        total += (week.a ?? 0) + (week.d ?? 0);
+      }
+    }
+    repository.lines_changed = total;
+  }
+  return status;
+}
+
+/** Fallback used when the contributors API keeps rate limiting us. */
+function cloneLinesChanged(repository, user, emails) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-stats-'));
+  const repoPath = path.join(dir, repository.name.replace(/\//g, '_'));
+  try {
+    execFileSync('git', [
+      'clone', '--bare', '--filter=blob:limit=1m', '--no-tags',
+      '--single-branch',
+      `https://${user}:${TOKEN}@github.com/${repository.name}.git`,
+      repoPath,
+    ], { stdio: 'ignore' });
+    const log = execFileSync('git', [
+      '-C', repoPath, 'log', '--numstat', '--pretty=tformat:',
+      ...emails.flatMap((email) => ['--author', email]),
+    ], { encoding: 'utf-8' });
+    let total = 0;
+    for (const line of log.split('\n')) {
+      const [additions, deletions] = line.trim().split(/\s+/);
+      total += (Number(additions) || 0) + (Number(deletions) || 0);
+    }
+    return total;
+  } catch (error) {
+    console.warn(`Could not clone ${repository.name}: ${error.message}`);
+    return 0;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function getLinesChanged(repositories, user, emails) {
+  for (const repository of repositories) {
+    for (let attempt = 0; ; attempt += 1) {
+      const status = await fetchLinesChanged(repository, user);
+      if (status === 200) break;
+      // 202 means GitHub is still computing the statistics; 403/429 are rate
+      // limits. Both are worth a short retry before falling back to cloning.
+      if (![202, 403, 429].includes(status)) {
+        console.warn(`Failed to get contributors for ${repository.name} (${status})`);
+        break;
+      }
+      if (attempt >= MAX_RETRIES) {
+        console.log(`Cloning ${repository.name} to get lines changed...`);
+        repository.lines_changed = cloneLinesChanged(repository, user, emails);
+        break;
+      }
+      await sleep(1000 + Math.floor(Math.random() * 4000));
+    }
+  }
+}
+
+function fillTemplate(template, values) {
+  return template.replace(/\{\{\s*([\w]+)\s*\}\}/g, (match, name) => {
+    if (!(name in values)) throw new Error(`Unknown template field: ${name}`);
+    const value = values[name];
+    return typeof value === 'number' ? value.toLocaleString('en-US') : value;
+  });
+}
+
+function escapeHtml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderLanguages(template, languages, total) {
+  const progress = [];
+  const list = [];
+  languages.forEach(([name, { size, color }], i) => {
+    const percent = total === 0 ? 0 : (100 * size) / total;
+    const fill = color || '#000';
+    progress.push(
+      `<span style="background-color: ${escapeHtml(fill)}; width: ${percent.toFixed(3)}%;" class="progress-item"></span>`,
+    );
+    list.push(
+      `<li style="animation-delay: ${(i + 1) * 150}ms;">
+  <svg xmlns="http://www.w3.org/2000/svg" class="octicon" style="fill: ${escapeHtml(fill)};" viewBox="0 0 16 16" version="1.1" width="16" height="16"><path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8z"></path></svg>
+  <span class="lang">${escapeHtml(name)}</span>
+  <span class="percent">${percent.toFixed(2)}%</span>
+</li>`,
+    );
+  });
+  return fillTemplate(template, {
+    progress: progress.join('\n'),
+    lang_list: list.join('\n'),
+  });
+}
+
+async function main() {
+  const info = await getBasicInfo();
+  console.log(`Collecting statistics for ${info.name} (${info.user})...`);
+
+  const state = { repositories: [], seen: new Set(), contributions: 0 };
+  for (const year of info.years) {
+    await getReposByYear(state, year, 0, 12);
+  }
+
+  const repositories = state.repositories.filter(
+    (repository) => !matchAny(EXCLUDE_REPOS, repository.name)
+      && !(EXCLUDE_PRIVATE && repository.private),
+  );
+  await getLinesChanged(repositories, info.user, info.emails);
+
+  const aggregate = {
+    name: escapeHtml(info.name),
+    contributions: state.contributions,
+    stars: 0,
+    forks: 0,
+    lines_changed: 0,
+    views: 0,
+    repos: repositories.length,
+  };
+  const languages = new Map();
+  let languagesTotal = 0;
+
+  for (const repository of repositories) {
+    aggregate.stars += repository.stars;
+    aggregate.forks += repository.forks;
+    aggregate.lines_changed += repository.lines_changed;
+    aggregate.views += repository.views;
+    for (const language of repository.languages) {
+      if (matchAny(EXCLUDE_LANGS, language.name)) continue;
+      const entry = languages.get(language.name) || { size: 0, color: null };
+      entry.size += language.size;
+      entry.color = language.color || entry.color;
+      languages.set(language.name, entry);
+      languagesTotal += language.size;
+    }
+  }
+
+  const sorted = [...languages.entries()].sort((a, b) => b[1].size - a[1].size);
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  const overview = fillTemplate(
+    fs.readFileSync(path.join(TEMPLATE_DIR, 'overview.svg'), 'utf-8'),
+    aggregate,
+  );
+  const languagesSvg = renderLanguages(
+    fs.readFileSync(path.join(TEMPLATE_DIR, 'languages.svg'), 'utf-8'),
+    sorted,
+    languagesTotal,
+  );
+  fs.writeFileSync(path.join(OUTPUT_DIR, 'overview.svg'), overview);
+  fs.writeFileSync(path.join(OUTPUT_DIR, 'languages.svg'), languagesSvg);
+  console.log(`Wrote overview.svg and languages.svg to ${OUTPUT_DIR}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/templates/languages.svg
+++ b/scripts/templates/languages.svg
@@ -1,0 +1,151 @@
+<svg width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-size: 14px;
+  line-height: 21px;
+}
+
+#background {
+  width: calc(100% - 10px);
+  height: calc(100% - 10px);
+  fill: white;
+  stroke: rgb(225, 228, 232);
+  stroke-width: 1px;
+  rx: 6px;
+  ry: 6px;
+}
+
+
+foreignObject {
+  width: calc(100% - 10px - 32px);
+  height: calc(100% - 10px - 24px);
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 0.75em;
+  line-height: 24px;
+  font-size: 16px;
+  font-weight: 600;
+  color: rgb(36, 41, 46);
+  fill: rgb(36, 41, 46);
+}
+
+
+ul {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+li {
+  display: inline-flex;
+  font-size: 12px;
+  margin-right: 1ch;
+  align-items: center;
+  flex-wrap: nowrap;
+  transform: translateX(-500%);
+  animation: slideIn 2s ease-in-out forwards;
+}
+
+@keyframes slideIn {
+  to {
+    transform: translateX(0);
+  }
+}
+
+div.ellipsis {
+  height: 176px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.octicon {
+  fill: rgb(88, 96, 105);
+  margin-right: 0.5ch;
+  vertical-align: top;
+}
+
+
+.progress {
+  display: flex;
+  height: 8px;
+  overflow: hidden;
+  background-color: rgb(225, 228, 232);
+  border-radius: 6px;
+  outline: 1px solid transparent;
+  margin-bottom: 1em;
+}
+
+
+.progress-item {
+  outline: 2px solid rgb(225, 228, 232);
+  border-collapse: collapse;
+}
+
+
+.lang {
+  font-weight: 600;
+  margin-right: 4px;
+  color: rgb(36, 41, 46);
+}
+
+
+.percent {
+  color: rgb(88, 96, 105)
+}
+
+@media (prefers-color-scheme: dark) {
+  #background {
+    fill: #0d1117;
+    stroke-width: 0.5px;
+  }
+  h2 {
+    color: #c9d1d9;
+    fill: #c9d1d9;
+  }
+  .octicon {
+    color: #8b949e;
+    fill: #8b949e;
+  }
+  .progress {
+    background-color: rgba(110, 118, 129, 0.4);
+  }
+  .progress-item {
+    outline: 2px solid #393f47;
+  }
+  .lang {
+    color: #c9d1d9;
+  }
+  .percent {
+    color: #8b949e;
+  }
+}
+</style>
+<g>
+<rect x="5" y="5" id="background" />
+<g>
+<foreignObject x="21" y="17" width="318" height="176">
+<div xmlns="http://www.w3.org/1999/xhtml" class="ellipsis">
+
+<h2>Languages Used (By File Size)</h2>
+
+<div>
+<span class="progress">
+{{ progress }}
+</span>
+</div>
+
+<ul>
+
+{{ lang_list }}
+
+</ul>
+
+</div>
+</foreignObject>
+</g>
+</g>
+</svg>

--- a/scripts/templates/overview.svg
+++ b/scripts/templates/overview.svg
@@ -1,0 +1,115 @@
+<svg width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-size: 14px;
+  line-height: 21px;
+}
+
+#background {
+  width: calc(100% - 10px);
+  height: calc(100% - 10px);
+  fill: white;
+  stroke: rgb(225, 228, 232);
+  stroke-width: 1px;
+  rx: 6px;
+  ry: 6px;
+}
+
+
+foreignObject {
+  width: calc(100% - 10px - 32px);
+  height: calc(100% - 10px - 32px);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: auto;
+}
+
+th {
+  padding: 0.5em;
+  padding-top: 0;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 600;
+  color: rgb(3, 102, 214);
+}
+
+
+td {
+  margin-bottom: 16px;
+  margin-top: 8px;
+  padding: 0.25em;
+  font-size: 12px;
+  line-height: 18px;
+  color: rgb(88, 96, 105);
+}
+
+
+tr {
+  transform: translateX(-200%);
+  animation: slideIn 2s ease-in-out forwards;
+}
+
+.octicon {
+  fill: rgb(88, 96, 105);
+  margin-right: 1ch;
+  vertical-align: top;
+}
+
+
+@keyframes slideIn {
+  to {
+    transform: translateX(0);
+  }
+}
+@media (prefers-color-scheme: dark) {
+  #background {
+    fill: #0d1117;
+    stroke-width: 0.5px;
+  }
+  th {
+    color: #58a6ff;
+  }
+  td {
+    color: #c9d1d9;
+  }
+  .octicon {
+    fill: #8b949e;
+  }
+}
+</style>
+<g>
+<rect x="5" y="5" id="background" />
+<g>
+<foreignObject x="21" y="21" width="318" height="168">
+<div xmlns="http://www.w3.org/1999/xhtml">
+
+<table>
+<thead><tr style="transform: translateX(0);">
+<th colspan="2">{{ name }}'s GitHub Statistics</th>
+</tr></thead>
+<tbody>
+
+<tr><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16"><path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"></path></svg>Stars</td><td>{{ stars }}</td></tr>
+
+<tr style="animation-delay: 150ms"><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" role="img"><path fill-rule="evenodd" d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.878A2.25 2.25 0 005.75 8.5h1.5v2.128a2.251 2.251 0 101.5 0V8.5h1.5a2.25 2.25 0 002.25-2.25v-.878a2.25 2.25 0 10-1.5 0v.878a.75.75 0 01-.75.75h-4.5A.75.75 0 015 6.25v-.878zm3.75 7.378a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm3-8.75a.75.75 0 100-1.5.75.75 0 000 1.5z"></path></svg>Forks</td><td>{{ forks }}</td></tr>
+
+<tr style="animation-delay: 300ms"><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2.5A2.5 2.5 0 013.5 0h8.75a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V1.5h-8a1 1 0 00-1 1v6.708A2.492 2.492 0 013.5 9h3.25a.75.75 0 010 1.5H3.5a1 1 0 100 2h5.75a.75.75 0 010 1.5H3.5A2.5 2.5 0 011 11.5v-9zm13.23 7.79a.75.75 0 001.06-1.06l-2.505-2.505a.75.75 0 00-1.06 0L9.22 9.229a.75.75 0 001.06 1.061l1.225-1.224v6.184a.75.75 0 001.5 0V9.066l1.224 1.224z"></path></svg>All-time contributions</td><td>{{ contributions }}</td></tr>
+
+<tr style="animation-delay: 450ms"><td><svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8.75 1.75a.75.75 0 00-1.5 0V5H4a.75.75 0 000 1.5h3.25v3.25a.75.75 0 001.5 0V6.5H12A.75.75 0 0012 5H8.75V1.75zM4 13a.75.75 0 000 1.5h8a.75.75 0 100-1.5H4z"></path></svg>Lines of code changed</td><td>{{ lines_changed }}</td></tr>
+
+<tr style="animation-delay: 600ms"><td><svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.679 7.932c.412-.621 1.242-1.75 2.366-2.717C5.175 4.242 6.527 3.5 8 3.5c1.473 0 2.824.742 3.955 1.715 1.124.967 1.954 2.096 2.366 2.717a.119.119 0 010 .136c-.412.621-1.242 1.75-2.366 2.717C10.825 11.758 9.473 12.5 8 12.5c-1.473 0-2.824-.742-3.955-1.715C2.92 9.818 2.09 8.69 1.679 8.068a.119.119 0 010-.136zM8 2c-1.981 0-3.67.992-4.933 2.078C1.797 5.169.88 6.423.43 7.1a1.619 1.619 0 000 1.798c.45.678 1.367 1.932 2.637 3.024C4.329 13.008 6.019 14 8 14c1.981 0 3.67-.992 4.933-2.078 1.27-1.091 2.187-2.345 2.637-3.023a1.619 1.619 0 000-1.798c-.45-.678-1.367-1.932-2.637-3.023C11.671 2.992 9.981 2 8 2zm0 8a2 2 0 100-4 2 2 0 000 4z"></path></svg>Repository views (past two weeks)</td><td>{{ views }}</td></tr>
+
+<tr style="animation-delay: 750ms"><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path></svg>Repositories with contributions</td><td>{{ repos }}</td></tr>
+
+</tbody>
+</table>
+
+</div>
+</foreignObject>
+</g>
+</g>
+</svg>

--- a/stats/languages.svg
+++ b/stats/languages.svg
@@ -1,0 +1,151 @@
+<svg width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-size: 14px;
+  line-height: 21px;
+}
+
+#background {
+  width: calc(100% - 10px);
+  height: calc(100% - 10px);
+  fill: white;
+  stroke: rgb(225, 228, 232);
+  stroke-width: 1px;
+  rx: 6px;
+  ry: 6px;
+}
+
+
+foreignObject {
+  width: calc(100% - 10px - 32px);
+  height: calc(100% - 10px - 24px);
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 0.75em;
+  line-height: 24px;
+  font-size: 16px;
+  font-weight: 600;
+  color: rgb(36, 41, 46);
+  fill: rgb(36, 41, 46);
+}
+
+
+ul {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+li {
+  display: inline-flex;
+  font-size: 12px;
+  margin-right: 1ch;
+  align-items: center;
+  flex-wrap: nowrap;
+  transform: translateX(-500%);
+  animation: slideIn 2s ease-in-out forwards;
+}
+
+@keyframes slideIn {
+  to {
+    transform: translateX(0);
+  }
+}
+
+div.ellipsis {
+  height: 176px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.octicon {
+  fill: rgb(88, 96, 105);
+  margin-right: 0.5ch;
+  vertical-align: top;
+}
+
+
+.progress {
+  display: flex;
+  height: 8px;
+  overflow: hidden;
+  background-color: rgb(225, 228, 232);
+  border-radius: 6px;
+  outline: 1px solid transparent;
+  margin-bottom: 1em;
+}
+
+
+.progress-item {
+  outline: 2px solid rgb(225, 228, 232);
+  border-collapse: collapse;
+}
+
+
+.lang {
+  font-weight: 600;
+  margin-right: 4px;
+  color: rgb(36, 41, 46);
+}
+
+
+.percent {
+  color: rgb(88, 96, 105)
+}
+
+@media (prefers-color-scheme: dark) {
+  #background {
+    fill: #0d1117;
+    stroke-width: 0.5px;
+  }
+  h2 {
+    color: #c9d1d9;
+    fill: #c9d1d9;
+  }
+  .octicon {
+    color: #8b949e;
+    fill: #8b949e;
+  }
+  .progress {
+    background-color: rgba(110, 118, 129, 0.4);
+  }
+  .progress-item {
+    outline: 2px solid #393f47;
+  }
+  .lang {
+    color: #c9d1d9;
+  }
+  .percent {
+    color: #8b949e;
+  }
+}
+</style>
+<g>
+<rect x="5" y="5" id="background" />
+<g>
+<foreignObject x="21" y="17" width="318" height="176">
+<div xmlns="http://www.w3.org/1999/xhtml" class="ellipsis">
+
+<h2>Languages Used (By File Size)</h2>
+
+<div>
+<span class="progress">
+
+</span>
+</div>
+
+<ul>
+
+
+
+</ul>
+
+</div>
+</foreignObject>
+</g>
+</g>
+</svg>

--- a/stats/overview.svg
+++ b/stats/overview.svg
@@ -1,0 +1,115 @@
+<svg width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-size: 14px;
+  line-height: 21px;
+}
+
+#background {
+  width: calc(100% - 10px);
+  height: calc(100% - 10px);
+  fill: white;
+  stroke: rgb(225, 228, 232);
+  stroke-width: 1px;
+  rx: 6px;
+  ry: 6px;
+}
+
+
+foreignObject {
+  width: calc(100% - 10px - 32px);
+  height: calc(100% - 10px - 32px);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: auto;
+}
+
+th {
+  padding: 0.5em;
+  padding-top: 0;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 600;
+  color: rgb(3, 102, 214);
+}
+
+
+td {
+  margin-bottom: 16px;
+  margin-top: 8px;
+  padding: 0.25em;
+  font-size: 12px;
+  line-height: 18px;
+  color: rgb(88, 96, 105);
+}
+
+
+tr {
+  transform: translateX(-200%);
+  animation: slideIn 2s ease-in-out forwards;
+}
+
+.octicon {
+  fill: rgb(88, 96, 105);
+  margin-right: 1ch;
+  vertical-align: top;
+}
+
+
+@keyframes slideIn {
+  to {
+    transform: translateX(0);
+  }
+}
+@media (prefers-color-scheme: dark) {
+  #background {
+    fill: #0d1117;
+    stroke-width: 0.5px;
+  }
+  th {
+    color: #58a6ff;
+  }
+  td {
+    color: #c9d1d9;
+  }
+  .octicon {
+    fill: #8b949e;
+  }
+}
+</style>
+<g>
+<rect x="5" y="5" id="background" />
+<g>
+<foreignObject x="21" y="21" width="318" height="168">
+<div xmlns="http://www.w3.org/1999/xhtml">
+
+<table>
+<thead><tr style="transform: translateX(0);">
+<th colspan="2">Noah Weidig's GitHub Statistics</th>
+</tr></thead>
+<tbody>
+
+<tr><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16"><path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"></path></svg>Stars</td><td>0</td></tr>
+
+<tr style="animation-delay: 150ms"><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" role="img"><path fill-rule="evenodd" d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.878A2.25 2.25 0 005.75 8.5h1.5v2.128a2.251 2.251 0 101.5 0V8.5h1.5a2.25 2.25 0 002.25-2.25v-.878a2.25 2.25 0 10-1.5 0v.878a.75.75 0 01-.75.75h-4.5A.75.75 0 015 6.25v-.878zm3.75 7.378a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm3-8.75a.75.75 0 100-1.5.75.75 0 000 1.5z"></path></svg>Forks</td><td>0</td></tr>
+
+<tr style="animation-delay: 300ms"><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 2.5A2.5 2.5 0 013.5 0h8.75a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V1.5h-8a1 1 0 00-1 1v6.708A2.492 2.492 0 013.5 9h3.25a.75.75 0 010 1.5H3.5a1 1 0 100 2h5.75a.75.75 0 010 1.5H3.5A2.5 2.5 0 011 11.5v-9zm13.23 7.79a.75.75 0 001.06-1.06l-2.505-2.505a.75.75 0 00-1.06 0L9.22 9.229a.75.75 0 001.06 1.061l1.225-1.224v6.184a.75.75 0 001.5 0V9.066l1.224 1.224z"></path></svg>All-time contributions</td><td>0</td></tr>
+
+<tr style="animation-delay: 450ms"><td><svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8.75 1.75a.75.75 0 00-1.5 0V5H4a.75.75 0 000 1.5h3.25v3.25a.75.75 0 001.5 0V6.5H12A.75.75 0 0012 5H8.75V1.75zM4 13a.75.75 0 000 1.5h8a.75.75 0 100-1.5H4z"></path></svg>Lines of code changed</td><td>0</td></tr>
+
+<tr style="animation-delay: 600ms"><td><svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.679 7.932c.412-.621 1.242-1.75 2.366-2.717C5.175 4.242 6.527 3.5 8 3.5c1.473 0 2.824.742 3.955 1.715 1.124.967 1.954 2.096 2.366 2.717a.119.119 0 010 .136c-.412.621-1.242 1.75-2.366 2.717C10.825 11.758 9.473 12.5 8 12.5c-1.473 0-2.824-.742-3.955-1.715C2.92 9.818 2.09 8.69 1.679 8.068a.119.119 0 010-.136zM8 2c-1.981 0-3.67.992-4.933 2.078C1.797 5.169.88 6.423.43 7.1a1.619 1.619 0 000 1.798c.45.678 1.367 1.932 2.637 3.024C4.329 13.008 6.019 14 8 14c1.981 0 3.67-.992 4.933-2.078 1.27-1.091 2.187-2.345 2.637-3.023a1.619 1.619 0 000-1.798c-.45-.678-1.367-1.932-2.637-3.023C11.671 2.992 9.981 2 8 2zm0 8a2 2 0 100-4 2 2 0 000 4z"></path></svg>Repository views (past two weeks)</td><td>0</td></tr>
+
+<tr style="animation-delay: 750ms"><td><svg class="octicon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path></svg>Repositories with contributions</td><td>0</td></tr>
+
+</tbody>
+</table>
+
+</div>
+</foreignObject>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
Ports the stats card generation out of `noahweidig/github-stats` so that repo can be deleted.

## Changes

- **`scripts/generate-stats.js`** — dependency-free Node port of the Zig generator (GraphQL contributions by year with window subdivision, traffic views, contributor line counts with retry + bare-clone fallback, repo/language exclusion globs).
- **`scripts/templates/{overview,languages}.svg`** — the `#gh-dark-mode-only:target` trick is replaced with a `@media (prefers-color-scheme: dark)` block, so a single SVG per card switches themes automatically. No more duplicated light/dark `<img>` pairs.
- **`stats/overview.svg`, `stats/languages.svg`** — committed placeholders, overwritten on the first workflow run.
- **`.github/workflows/github-stats.yml`** — daily cron (plus manual dispatch) that regenerates and commits the cards. Uses `secrets.ACCESS_TOKEN`, falling back to `GITHUB_TOKEN`.
- **README** — points at the local `./stats/*.svg` instead of `https://github.com/noahweidig/github-stats/blob/generated/...`, which was a rendered HTML page URL, not an image, and never displayed.
- **`.github/workflows/render-readme.yml`** — copies `icons/`, `stats/`, `profile-3d-contrib/`, and the banner into `_site/`. Only `index.html` was being uploaded, so every image 404'd on the Pages site.
- **`package.json`** — adds `npm run stats`.

## Notes

- `ACCESS_TOKEN` (a PAT with `repo` + `user:email`) should be set as a repo secret; the default `GITHUB_TOKEN` fallback cannot see private repos, traffic views, or verified emails.
- The renderer was verified end to end against mocked API responses (counts, percentages, HTML escaping of the display name).
- Follow-up in `noahweidig/github-stats` marks that repo deprecated so it can be deleted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxTcr9o3fiy2WbhsZiL6ax)_